### PR TITLE
Add support for per-request timeouts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@ module github.com/dropbox/godropbox
 go 1.13
 
 require (
+	github.com/davecgh/go-spew v1.1.1
 	github.com/gogo/protobuf v1.3.1
 	github.com/kr/pretty v0.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -7,6 +10,11 @@ github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -14,5 +22,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/memcache/client_adapter.go
+++ b/memcache/client_adapter.go
@@ -1,0 +1,300 @@
+package memcache
+
+import (
+	"context"
+	"io"
+
+	"github.com/dropbox/godropbox/errors"
+)
+
+// contextlessClientAdapter is a Client that passes context.Background() to all wrapped methods.
+type contextlessClientAdapter struct {
+	inner ContextClient
+}
+
+func newContextlessClientAdapter(inner ContextClient) Client {
+	return &contextlessClientAdapter{inner}
+}
+
+// Get implements Client.Get
+func (c *contextlessClientAdapter) Get(key string) GetResponse {
+	return c.inner.Get(context.Background(), key)
+}
+
+// GetMulti implements Client.GetMulti
+func (c *contextlessClientAdapter) GetMulti(keys []string) map[string]GetResponse {
+	return c.inner.GetMulti(context.Background(), keys)
+}
+
+// GetSentinels implements Client.GetSentinels
+func (c *contextlessClientAdapter) GetSentinels(keys []string) map[string]GetResponse {
+	return c.inner.GetSentinels(context.Background(), keys)
+}
+
+// Set implements Client.Set
+func (c *contextlessClientAdapter) Set(item *Item) MutateResponse {
+	return c.inner.Set(context.Background(), item)
+}
+
+// SetMulti implements Client.SetMulti
+func (c *contextlessClientAdapter) SetMulti(items []*Item) []MutateResponse {
+	return c.inner.SetMulti(context.Background(), items)
+}
+
+// SetSentinels implements Client.SetSentinels
+func (c *contextlessClientAdapter) SetSentinels(items []*Item) []MutateResponse {
+	return c.inner.SetSentinels(context.Background(), items)
+}
+
+// CasMulti implements Client.CasMulti
+func (c *contextlessClientAdapter) CasMulti(items []*Item) []MutateResponse {
+	return c.inner.CasMulti(context.Background(), items)
+}
+
+// CasSentinels implements Client.CasSentinels
+func (c *contextlessClientAdapter) CasSentinels(items []*Item) []MutateResponse {
+	return c.inner.CasSentinels(context.Background(), items)
+}
+
+// Add implements Client.Add
+func (c *contextlessClientAdapter) Add(item *Item) MutateResponse {
+	return c.inner.Add(context.Background(), item)
+}
+
+// AddMulti implements Client.AddMulti
+func (c *contextlessClientAdapter) AddMulti(item []*Item) []MutateResponse {
+	return c.inner.AddMulti(context.Background(), item)
+}
+
+// Replace implements Client.Replace
+func (c *contextlessClientAdapter) Replace(item *Item) MutateResponse {
+	return c.inner.Replace(context.Background(), item)
+}
+
+// Delete implements Client.Delete
+func (c *contextlessClientAdapter) Delete(key string) MutateResponse {
+	return c.inner.Delete(context.Background(), key)
+}
+
+// DeleteMulti implements Client.DeleteMulti
+func (c *contextlessClientAdapter) DeleteMulti(keys []string) []MutateResponse {
+	return c.inner.DeleteMulti(context.Background(), keys)
+}
+
+// Append implements Client.Append
+func (c *contextlessClientAdapter) Append(key string, value []byte) MutateResponse {
+	return c.inner.Append(context.Background(), key, value)
+}
+
+// Prepend implements Client.Prepend
+func (c *contextlessClientAdapter) Prepend(key string, value []byte) MutateResponse {
+	return c.inner.Prepend(context.Background(), key, value)
+}
+
+// Increment implements Client.Increment
+func (c *contextlessClientAdapter) Increment(
+	key string,
+	delta uint64,
+	initValue uint64,
+	expiration uint32) CountResponse {
+	return c.inner.Increment(context.Background(), key, delta, initValue, expiration)
+}
+
+// Decrement implements Client.Decrement
+func (c *contextlessClientAdapter) Decrement(
+	key string,
+	delta uint64,
+	initValue uint64,
+	expiration uint32) CountResponse {
+	return c.inner.Decrement(context.Background(), key, delta, initValue, expiration)
+}
+
+// Flush implements Client.Flush
+func (c *contextlessClientAdapter) Flush(expiration uint32) Response {
+	return c.inner.Flush(context.Background(), expiration)
+}
+
+// Stats implements Client.Stat
+func (c *contextlessClientAdapter) Stat(statsKey string) StatResponse {
+	return c.inner.Stat(context.Background(), statsKey)
+}
+
+// Version implements Client.Version
+func (c *contextlessClientAdapter) Version() VersionResponse {
+	return c.inner.Version(context.Background())
+}
+
+// Verbosity implements Client.Verbosity
+func (c *contextlessClientAdapter) Verbosity(verbosity uint32) Response {
+	return c.inner.Verbosity(context.Background(), verbosity)
+}
+
+// contextlessClientShardAdapter is a ClientShard that passes context.Background() to all wrapped methods.
+type contextlessClientShardAdapter struct {
+	contextlessClientAdapter
+	innerShard ContextClientShard
+}
+
+func newContextlessClientShardAdapter(inner ContextClientShard) ClientShard {
+	return &contextlessClientShardAdapter{contextlessClientAdapter{inner}, inner}
+}
+
+// ShardId implements ClientShard.ShardId
+func (c *contextlessClientShardAdapter) ShardId() int {
+	return c.innerShard.ShardId()
+}
+
+// IsValidState implements ClientShard.IsValidState
+func (c *contextlessClientShardAdapter) IsValidState() bool {
+	return c.innerShard.IsValidState()
+}
+
+// ignoreContextClientAdapter is a ContextClient ignores the passed context.Context
+type ignoreContextClientAdapter struct {
+	inner Client
+}
+
+func newIgnoreContextClientAdapter(inner Client) ContextClient {
+	return &ignoreContextClientAdapter{inner}
+}
+
+// Get implements Client.Get
+func (c *ignoreContextClientAdapter) Get(ctx context.Context, key string) GetResponse {
+	return c.inner.Get(key)
+}
+
+// GetMulti implements ContextClient.GetMulti
+func (c *ignoreContextClientAdapter) GetMulti(ctx context.Context, keys []string) map[string]GetResponse {
+	return c.inner.GetMulti(keys)
+}
+
+// GetSentinels implements ContextClient.GetSentinels
+func (c *ignoreContextClientAdapter) GetSentinels(ctx context.Context, keys []string) map[string]GetResponse {
+	return c.inner.GetSentinels(keys)
+}
+
+// Set implements ContextClient.Set
+func (c *ignoreContextClientAdapter) Set(ctx context.Context, item *Item) MutateResponse {
+	return c.inner.Set(item)
+}
+
+// SetMulti implements ContextClient.SetMulti
+func (c *ignoreContextClientAdapter) SetMulti(ctx context.Context, items []*Item) []MutateResponse {
+	return c.inner.SetMulti(items)
+}
+
+// SetSentinels implements ContextClient.SetSentinels
+func (c *ignoreContextClientAdapter) SetSentinels(ctx context.Context, items []*Item) []MutateResponse {
+	return c.inner.SetSentinels(items)
+}
+
+// CasMulti implements ContextClient.CasMulti
+func (c *ignoreContextClientAdapter) CasMulti(ctx context.Context, items []*Item) []MutateResponse {
+	return c.inner.CasMulti(items)
+}
+
+// CasSentinels implements ContextClient.CasSentinels
+func (c *ignoreContextClientAdapter) CasSentinels(ctx context.Context, items []*Item) []MutateResponse {
+	return c.inner.CasSentinels(items)
+}
+
+// Add implements ContextClient.Add
+func (c *ignoreContextClientAdapter) Add(ctx context.Context, item *Item) MutateResponse {
+	return c.inner.Add(item)
+}
+
+// AddMulti implements ContextClient.AddMulti
+func (c *ignoreContextClientAdapter) AddMulti(ctx context.Context, item []*Item) []MutateResponse {
+	return c.inner.AddMulti(item)
+}
+
+// Replace implements ContextClient.Replace
+func (c *ignoreContextClientAdapter) Replace(ctx context.Context, item *Item) MutateResponse {
+	return c.inner.Replace(item)
+}
+
+// Delete implements ContextClient.Delete
+func (c *ignoreContextClientAdapter) Delete(ctx context.Context, key string) MutateResponse {
+	return c.inner.Delete(key)
+}
+
+// DeleteMulti implements ContextClient.DeleteMulti
+func (c *ignoreContextClientAdapter) DeleteMulti(ctx context.Context, keys []string) []MutateResponse {
+	return c.inner.DeleteMulti(keys)
+}
+
+// Append implements ContextClient.Append
+func (c *ignoreContextClientAdapter) Append(ctx context.Context, key string, value []byte) MutateResponse {
+	return c.inner.Append(key, value)
+}
+
+// Prepend implements ContextClient.Prepend
+func (c *ignoreContextClientAdapter) Prepend(ctx context.Context, key string, value []byte) MutateResponse {
+	return c.inner.Prepend(key, value)
+}
+
+// Increment implements ContextClient.Increment
+func (c *ignoreContextClientAdapter) Increment(ctx context.Context,
+	key string,
+	delta uint64,
+	initValue uint64,
+	expiration uint32) CountResponse {
+	return c.inner.Increment(key, delta, initValue, expiration)
+}
+
+// Decrement implements ContextClient.Decrement
+func (c *ignoreContextClientAdapter) Decrement(ctx context.Context,
+	key string,
+	delta uint64,
+	initValue uint64,
+	expiration uint32) CountResponse {
+	return c.inner.Decrement(key, delta, initValue, expiration)
+}
+
+// Flush implements ContextClient.Flush
+func (c *ignoreContextClientAdapter) Flush(ctx context.Context, expiration uint32) Response {
+	return c.inner.Flush(expiration)
+}
+
+// Stats implements ContextClient.Stat
+func (c *ignoreContextClientAdapter) Stat(ctx context.Context, statsKey string) StatResponse {
+	return c.inner.Stat(statsKey)
+}
+
+// Version implements ContextClient.Version
+func (c *ignoreContextClientAdapter) Version(ctx context.Context) VersionResponse {
+	return c.inner.Version()
+}
+
+// Verbosity implements ContextClient.Verbosity
+func (c *ignoreContextClientAdapter) Verbosity(ctx context.Context, verbosity uint32) Response {
+	return c.inner.Verbosity(verbosity)
+}
+
+// ignoreContextClientAdapter is a ContextClientShard ignores the passed context.Context
+type ignoreContextClientShardAdapter struct {
+	ignoreContextClientAdapter
+	innerShard ClientShard
+}
+
+func newIgnoreContextClientShardAdapter(inner ClientShard) ContextClientShard {
+	return &ignoreContextClientShardAdapter{ignoreContextClientAdapter{inner}, inner}
+}
+
+// ShardId implements the ClientShard interface.
+func (c *ignoreContextClientShardAdapter) ShardId() int {
+	return c.innerShard.ShardId()
+}
+
+// IsValidState implements the ClientShard interface.
+func (c *ignoreContextClientShardAdapter) IsValidState() bool {
+	return c.innerShard.IsValidState()
+}
+
+// noDeadlineReadWriter is a DeadlineReaderWriter that ignores the context's deadline.
+type noDeadlineReadWriter struct{ io.ReadWriter }
+
+// SetDeadlineFromContext implements DeadlineReaderWriter interface.
+func (n *noDeadlineReadWriter) SetDeadlineFromContext(ctx context.Context) error {
+	return errors.New("cannot override deadline on a non-context client")
+}

--- a/net2/managed_connection_test.go
+++ b/net2/managed_connection_test.go
@@ -1,0 +1,81 @@
+package net2
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/dropbox/godropbox/resource_pool"
+)
+
+type fakeConn struct {
+	net.Conn
+	writeDeadline, readDeadline time.Time
+}
+
+func (f *fakeConn) SetReadDeadline(t time.Time) error {
+	f.readDeadline = t
+	return nil
+}
+func (f *fakeConn) SetWriteDeadline(t time.Time) error {
+	f.readDeadline = t
+	return nil
+}
+func (f *fakeConn) Read(b []byte) (n int, err error)  { return 0, nil }
+func (f *fakeConn) Write(b []byte) (n int, err error) { return 0, nil }
+
+type fakeManagedHandle struct {
+	resource_pool.ManagedHandle
+	conn net.Conn
+}
+
+func (f *fakeManagedHandle) Handle() (interface{}, error) {
+	return f.conn, nil
+}
+
+func TestContextDeadline(t *testing.T) {
+	options := ConnectionOptions{
+		ReadTimeout:  time.Hour,
+		WriteTimeout: time.Hour,
+	}
+	b := make([]byte, 0, 10)
+	conn := &fakeConn{}
+	mconn := NewManagedConn("network", "address", &fakeManagedHandle{conn: conn},
+		nil, options)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	mconn.SetDeadlineFromContext(ctx)
+	mconn.Read(b)
+	mconn.Write(b)
+
+	if got, want := time.Until(conn.readDeadline), time.Minute; got > want {
+		t.Errorf("ContextRead() used read timeout=%s, want <= %s", got, want)
+	}
+	if got, want := time.Until(conn.writeDeadline), time.Minute; got > want {
+		t.Errorf("ContextRead() used write timeout=%s, want <= %s", got, want)
+	}
+}
+
+func TestPoolDeadline(t *testing.T) {
+	options := ConnectionOptions{
+		ReadTimeout:  time.Hour,
+		WriteTimeout: time.Hour,
+	}
+	b := make([]byte, 0, 10)
+	conn := &fakeConn{}
+	mconn := NewManagedConn("network", "address", &fakeManagedHandle{conn: conn},
+		nil, options)
+
+	mconn.SetDeadlineFromContext(context.Background())
+	mconn.Read(b)
+	mconn.Write(b)
+
+	if got, want := time.Until(conn.readDeadline), time.Hour; got > want {
+		t.Errorf("ContextRead() used read timeout=%s, want <= %s", got, want)
+	}
+	if got, want := time.Until(conn.writeDeadline), time.Hour; got > want {
+		t.Errorf("ContextRead() used write timeout=%s, want <= %s", got, want)
+	}
+}


### PR DESCRIPTION
Introduces ContextClient, ContextClientShard interfaces whose methods
accept a context.Context parameter. The request deadline is set to the
context deadline if it is set, the ConnectionOptions timeout if that is
set, or is left unmodified if neither are set.

The primary interfaces (Client, ClientShard) are unchanged and simply
pass context.Background() to a wrapped context client.

ManagedConn adds a method to set a deadline from a context. Modifying
the existing interface avoids forking the managed pool and sharding
interfaces, and is unlikely to break any code since it's unlikely to
be implemented elsewhere.

ShardedClient wraps a ContextShardedClient by adapting the caller's
builder and the resulting client to ignore the context parameter.